### PR TITLE
feat: nix flake

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -1,3 +1,3 @@
 [target.x86_64-unknown-linux-gnu]
-linker = "clang"          # or "gcc" — clang often works better with Swift interop anyway
-rustflags = ["-C", "link-arg=-fuse-ld=/usr/bin/ld"]   # explicit GNU ld (not lld)
+linker = "clang"                           # or "gcc" — clang often works better with Swift interop anyway
+rustflags = ["-C", "link-arg=-fuse-ld=ld"] # explicit GNU ld (not lld)

--- a/flake.lock
+++ b/flake.lock
@@ -1,0 +1,61 @@
+{
+  "nodes": {
+    "flake-utils": {
+      "inputs": {
+        "systems": "systems"
+      },
+      "locked": {
+        "lastModified": 1731533236,
+        "narHash": "sha256-l0KFg5HjrsfsO/JpG+r7fRrqm12kzFHyUHqHCVpMMbI=",
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "rev": "11707dc2f618dd54ca8739b309ec4fc024de578b",
+        "type": "github"
+      },
+      "original": {
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "type": "github"
+      }
+    },
+    "nixpkgs": {
+      "locked": {
+        "lastModified": 1773068389,
+        "narHash": "sha256-vMrm7Pk2hjBRPnCSjhq1pH0bg350Z+pXhqZ9ICiqqCs=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "44bae273f9f82d480273bab26f5c50de3724f52f",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "nixos-25.11",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "root": {
+      "inputs": {
+        "flake-utils": "flake-utils",
+        "nixpkgs": "nixpkgs"
+      }
+    },
+    "systems": {
+      "locked": {
+        "lastModified": 1681028828,
+        "narHash": "sha256-Vy1rq5AaRuLzOxct8nz4T6wlgyUR7zLU309k9mBC768=",
+        "owner": "nix-systems",
+        "repo": "default",
+        "rev": "da67096a3b9bf56a91d16901293e51ba5b49a27e",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-systems",
+        "repo": "default",
+        "type": "github"
+      }
+    }
+  },
+  "root": "root",
+  "version": 7
+}

--- a/flake.nix
+++ b/flake.nix
@@ -1,0 +1,116 @@
+{
+  inputs = {
+    nixpkgs.url = "github:NixOS/nixpkgs/nixos-25.11";
+    flake-utils.url = "github:numtide/flake-utils";
+  };
+
+  outputs =
+    {
+      self,
+      nixpkgs,
+      flake-utils,
+    }:
+    flake-utils.lib.eachDefaultSystem (
+      system:
+      let
+        pkgs = import nixpkgs { inherit system; };
+        inherit (pkgs) lib stdenv makeWrapper;
+
+        swiftly =
+          let
+            arch = stdenv.hostPlatform.parsed.cpu.name;
+            pname = "swiftly";
+            version = "1.1.1";
+
+            platformConfig =
+              if stdenv.isLinux then
+                {
+                  url = "https://download.swift.org/swiftly/linux/swiftly-${version}-${arch}.tar.gz";
+                  sha256 = "sha256-3F+UMIszRVUw9BULQSUnWWozyFJafVmwJbWYUg6S0SE=";
+                  unpack = "tar zxf $src";
+                  install = "cp swiftly $out/bin/swiftly";
+                  extraNativeBuildInputs = [ ];
+                }
+              else if stdenv.isDarwin then
+                {
+                  url = "https://download.swift.org/swiftly/darwin/swiftly-${version}.pkg";
+                  sha256 = "sha256-k5MvTejZ8zgWjwHidtMRQhukpTjmU2JdnrOKdqIWz2c=";
+                  unpack = ''
+                    xar -xf $src
+                    cat Payload | gunzip | cpio -id
+                  '';
+                  install = "cp .swiftly/bin/swiftly $out/bin/swiftly";
+                  extraNativeBuildInputs = [ pkgs.xar ];
+                }
+              else
+                throw "swiftly: unsupported system ${stdenv.hostPlatform.system}";
+          in
+          stdenv.mkDerivation {
+            inherit pname version;
+
+            src = pkgs.fetchurl {
+              inherit (platformConfig) url sha256;
+            };
+
+            nativeBuildInputs = [ makeWrapper ] ++ platformConfig.extraNativeBuildInputs;
+
+            unpackPhase = platformConfig.unpack;
+
+            installPhase = ''
+              runHook preInstall
+              mkdir -p $out/bin
+              ${platformConfig.install}
+              chmod +x $out/bin/swiftly
+              runHook postInstall
+            '';
+
+            meta = with lib; {
+              description = "A Swift toolchain installer and manager, written in Swift.";
+              homepage = "https://github.com/swiftlang/swiftly";
+              license = licenses.asl20;
+              platforms = platforms.all;
+            };
+          };
+      in
+      {
+        packages = {
+          inherit swiftly;
+        };
+
+        devShells.default =
+          with pkgs;
+          mkShell rec {
+            nativeBuildInputs = with pkgs; [
+              just
+              # swift
+              swiftly
+              rustup
+
+              clang
+              gcc
+              # binutils
+              fontconfig
+              pkg-config
+            ];
+
+            buildInputs = with pkgs; [
+              dbus
+              ncurses
+              sqlite
+              libxml2_13
+            ];
+
+            shellHook = ''
+              SWIFTLY_HOME="''${SWIFTLY_HOME_DIR:-$HOME/.local/share/swiftly}"
+              SWIFT_TOOLCHAIN=$(ls -1 "$SWIFTLY_HOME/toolchains" 2>/dev/null | sort -V | tail -1)
+              export SWIFT_LIBRARY_PATH="$SWIFTLY_HOME/toolchains/$SWIFT_TOOLCHAIN/usr/lib/swift_static/linux"
+
+              export LIBRARY_PATH="${pkgs.gcc.cc}/lib:${pkgs.gcc.cc}/lib/gcc/${pkgs.stdenv.hostPlatform.config}/${lib.getVersion pkgs.gcc.cc}:${pkgs.libgcc.lib}/lib:''${LIBRARY_PATH:-}"
+            '';
+
+            LD_LIBRARY_PATH = pkgs.lib.makeLibraryPath buildInputs;
+            SLINT_ENABLE_EXPERIMENTAL_FEATURES = 1;
+          };
+      }
+    );
+}

--- a/flake.nix
+++ b/flake.nix
@@ -83,12 +83,18 @@
             nativeBuildInputs = with pkgs; [
               just
               # swift
+              # swiftpm
               swiftly
               rustup
 
               clang
-              gcc
               # binutils
+              gcc
+              perl
+              curl
+              git
+              cacert
+              gnupg
               fontconfig
               pkg-config
             ];
@@ -98,17 +104,16 @@
               ncurses
               sqlite
               libxml2_13
+              swiftPackages.Dispatch
             ];
 
             shellHook = ''
               SWIFTLY_HOME="''${SWIFTLY_HOME_DIR:-$HOME/.local/share/swiftly}"
               SWIFT_TOOLCHAIN=$(ls -1 "$SWIFTLY_HOME/toolchains" 2>/dev/null | sort -V | tail -1)
               export SWIFT_LIBRARY_PATH="$SWIFTLY_HOME/toolchains/$SWIFT_TOOLCHAIN/usr/lib/swift_static/linux"
-
-              export LIBRARY_PATH="${pkgs.gcc.cc}/lib:${pkgs.gcc.cc}/lib/gcc/${pkgs.stdenv.hostPlatform.config}/${lib.getVersion pkgs.gcc.cc}:${pkgs.libgcc.lib}/lib:''${LIBRARY_PATH:-}"
             '';
 
-            LD_LIBRARY_PATH = pkgs.lib.makeLibraryPath buildInputs;
+            LD_LIBRARY_PATH = lib.makeLibraryPath buildInputs;
             SLINT_ENABLE_EXPERIMENTAL_FEATURES = 1;
           };
       }


### PR DESCRIPTION
adds
	- devshell
	- swiftly package
	- paicord package (soon)

im not a swift person so i dont really know the swift process but i believe after entering the flake with swiftly you have to do

```bash
swiftly init # it gave me an error that nixos isnt supported but i just picked ubuntu 24 and it seemed to work
swiftly install --use latest
```

and then after that you should be good for whatever devshells you enter

i also cant test on anything besides `x86_64-linux` but im pretty sure ive correctly added support for macos and other architectures