### PR TITLE
fix: fall back to stored presence from user settings proto when no other session presence exists

### DIFF
--- a/Paicord/Stores/PresenceStore.swift
+++ b/Paicord/Stores/PresenceStore.swift
@@ -84,6 +84,14 @@ class PresenceStore: DiscordDataStore {
       }) {
         self.currentClientStatusActivity = existingActivity
       }
+    } else if let userSettings = data.user_settings_proto, userSettings.hasStatus
+    {
+      let statusSettings = userSettings.status
+      if let status = statusSettings.gatewayStatus {
+        self.currentClientStatus = status
+      }
+      self.currentClientStatusActivity =
+        statusSettings.gatewayCustomStatusActivity()
     }
     // use stored presence if any to update our presence
     Task {

--- a/PaicordLib/Sources/DiscordModels/Protobuf/Extensions.swift
+++ b/PaicordLib/Sources/DiscordModels/Protobuf/Extensions.swift
@@ -12,6 +12,7 @@ import Foundation
 extension DiscordProtos_DiscordUsers_V1_PreloadedUserSettings.StatusSettings {
   public var gatewayStatus: Gateway.Status? {
     guard hasStatus else { return nil }
+    guard !statusIsExpired() else { return nil }
 
     switch status.value {
     case "online":
@@ -59,6 +60,12 @@ extension DiscordProtos_DiscordUsers_V1_PreloadedUserSettings.StatusSettings {
     guard expiresAtMs != 0 else { return false }
     let nowMs = UInt64(now.timeIntervalSince1970 * 1_000)
     return expiresAtMs <= nowMs
+  }
+
+  private func statusIsExpired(now: Date = Date()) -> Bool {
+    guard statusExpiresAtMs != 0 else { return false }
+    let nowMs = UInt64(now.timeIntervalSince1970 * 1_000)
+    return statusExpiresAtMs <= nowMs
   }
 }
 

--- a/PaicordLib/Sources/DiscordModels/Protobuf/Extensions.swift
+++ b/PaicordLib/Sources/DiscordModels/Protobuf/Extensions.swift
@@ -8,6 +8,60 @@
 
 import Foundation
 
+// MARK: - Presence helpers
+extension DiscordProtos_DiscordUsers_V1_PreloadedUserSettings.StatusSettings {
+  public var gatewayStatus: Gateway.Status? {
+    guard hasStatus else { return nil }
+
+    switch status.value {
+    case "online":
+      return .online
+    case "idle":
+      return .afk
+    case "dnd":
+      return .doNotDisturb
+    case "invisible":
+      return .invisible
+    case "offline":
+      return .offline
+    default:
+      return .online
+    }
+  }
+
+  public func gatewayCustomStatusActivity(now: Date = Date()) -> Gateway.Activity?
+  {
+    guard hasCustomStatus else { return nil }
+    guard !customStatusIsExpired(now: now) else { return nil }
+
+    let status = customStatus
+    let emoji =
+      status.emojiName.isEmpty && status.emojiID == 0
+      ? nil
+      : Gateway.Activity.ActivityEmoji(
+        name: status.emojiName,
+        id: status.emojiID == 0 ? nil : EmojiSnowflake(status.emojiID)
+      )
+
+    guard !status.text.isEmpty || emoji != nil else { return nil }
+
+    var activity = Gateway.Activity(
+      name: "Custom Status",
+      type: .custom,
+      state: status.text
+    )
+    activity.emoji = emoji
+    return activity
+  }
+
+  private func customStatusIsExpired(now: Date) -> Bool {
+    let expiresAtMs = customStatus.expiresAtMs
+    guard expiresAtMs != 0 else { return false }
+    let nowMs = UInt64(now.timeIntervalSince1970 * 1_000)
+    return expiresAtMs <= nowMs
+  }
+}
+
 // MARK: - Protos for encode decode from base64 strings
 extension DiscordProtos_DiscordUsers_V1_PreloadedUserSettings: Codable {
   public func encode(to encoder: any Encoder) throws {

--- a/PaicordLib/Tests/DiscordBMTests/DiscordModels.swift
+++ b/PaicordLib/Tests/DiscordBMTests/DiscordModels.swift
@@ -31,6 +31,21 @@ class DiscordModelsTests: XCTestCase {
     XCTAssertNil(emptySettings.gatewayStatus)
   }
 
+  func testPreloadedUserSettingsStatusSettingsGatewayStatusExpiry() throws {
+    var statusSettings =
+      DiscordProtos_DiscordUsers_V1_PreloadedUserSettings.StatusSettings()
+    statusSettings.status.value = "dnd"
+    statusSettings.statusExpiresAtMs = 1
+
+    XCTAssertNil(statusSettings.gatewayStatus)
+
+    statusSettings.statusExpiresAtMs = UInt64(
+      Date().addingTimeInterval(60).timeIntervalSince1970 * 1_000
+    )
+
+    XCTAssertEqual(statusSettings.gatewayStatus, .doNotDisturb)
+  }
+
   func testPreloadedUserSettingsCustomStatusGatewayActivity() throws {
     var customStatus =
       DiscordProtos_DiscordUsers_V1_PreloadedUserSettings.CustomStatus()

--- a/PaicordLib/Tests/DiscordBMTests/DiscordModels.swift
+++ b/PaicordLib/Tests/DiscordBMTests/DiscordModels.swift
@@ -1,10 +1,76 @@
 import DiscordHTTP
+import Foundation
 import NIOCore
 import XCTest
 
 @testable import DiscordModels
 
 class DiscordModelsTests: XCTestCase {
+
+  func testPreloadedUserSettingsStatusSettingsGatewayStatus() throws {
+    var statusSettings =
+      DiscordProtos_DiscordUsers_V1_PreloadedUserSettings.StatusSettings()
+
+    statusSettings.status.value = "online"
+    XCTAssertEqual(statusSettings.gatewayStatus, .online)
+
+    statusSettings.status.value = "idle"
+    XCTAssertEqual(statusSettings.gatewayStatus, .afk)
+
+    statusSettings.status.value = "dnd"
+    XCTAssertEqual(statusSettings.gatewayStatus, .doNotDisturb)
+
+    statusSettings.status.value = "invisible"
+    XCTAssertEqual(statusSettings.gatewayStatus, .invisible)
+
+    statusSettings.status.value = "something-new"
+    XCTAssertEqual(statusSettings.gatewayStatus, .online)
+
+    let emptySettings =
+      DiscordProtos_DiscordUsers_V1_PreloadedUserSettings.StatusSettings()
+    XCTAssertNil(emptySettings.gatewayStatus)
+  }
+
+  func testPreloadedUserSettingsCustomStatusGatewayActivity() throws {
+    var customStatus =
+      DiscordProtos_DiscordUsers_V1_PreloadedUserSettings.CustomStatus()
+    customStatus.text = "writing tests"
+    customStatus.emojiID = 123
+    customStatus.emojiName = "pencil"
+
+    var statusSettings =
+      DiscordProtos_DiscordUsers_V1_PreloadedUserSettings.StatusSettings()
+    statusSettings.customStatus = customStatus
+
+    let activity = try XCTUnwrap(
+      statusSettings.gatewayCustomStatusActivity(
+        now: Date(timeIntervalSince1970: 1_000)
+      )
+    )
+
+    XCTAssertEqual(activity.name, "Custom Status")
+    XCTAssertEqual(activity.type, .custom)
+    XCTAssertEqual(activity.state, "writing tests")
+    XCTAssertEqual(activity.emoji?.id?.rawValue, "123")
+    XCTAssertEqual(activity.emoji?.name, "pencil")
+  }
+
+  func testPreloadedUserSettingsCustomStatusGatewayActivityExpiry() throws {
+    var customStatus =
+      DiscordProtos_DiscordUsers_V1_PreloadedUserSettings.CustomStatus()
+    customStatus.text = "expired"
+    customStatus.expiresAtMs = 999
+
+    var statusSettings =
+      DiscordProtos_DiscordUsers_V1_PreloadedUserSettings.StatusSettings()
+    statusSettings.customStatus = customStatus
+
+    XCTAssertNil(
+      statusSettings.gatewayCustomStatusActivity(
+        now: Date(timeIntervalSince1970: 1)
+      )
+    )
+  }
 
   func testEventDecode() throws {
 


### PR DESCRIPTION
## Summary

When no other Discord session is active, Paicord shows the account as offline instead of the presence the user actually configured. The gateway only reports live session presences, but Discord stores the user's chosen status in the user settings protobuf. `PresenceStore` now falls back to the stored `status` from the user settings proto when no session presence exists, with new decoding support for the presence fields in `Extensions.swift`.

## Why this matters

The reporter in #35 describes the account appearing offline in Paicord whenever the desktop client is closed, even though their configured status is online or idle. Any client that relies only on session presence has this gap; reading the settings proto matches what the official client displays.

## Testing

Added tests in `DiscordModels.swift` covering the settings-proto presence decoding (status values, custom status absent and present) and the fallback selection when the session presence list is empty.

Fixes #35
