### PR TITLE
fix: watchOS decoding and error reporting

### DIFF
--- a/PaicordLib/Sources/DiscordHTTP/HTTP Types.swift
+++ b/PaicordLib/Sources/DiscordHTTP/HTTP Types.swift
@@ -346,3 +346,49 @@ public enum DiscordHTTPError: Error, CustomStringConvertible {
     }
   }
 }
+
+extension DiscordHTTPError: LocalizedError, CustomNSError {
+  public var errorDescription: String? {
+    switch self {
+    case .rateLimited:
+      return "Discord is limiting requests. Wait before trying again."
+    case .badStatusCode(let response):
+      return "Discord request failed (HTTP \(response.status.code))."
+    case .cantDecodeJSONErrorFromSuccessfulResponse(let response):
+      return "Expected an error response, but Discord reported success (HTTP \(response.status.code))."
+    case .emptyBody(let response):
+      return "Discord returned an empty response (HTTP \(response.status.code))."
+    case .noContentTypeHeader(let response):
+      return "Discord didn't specify the response format (HTTP \(response.status.code))."
+    case .authenticationHeaderRequired:
+      return "This request requires authentication. Sign in before trying again."
+    case .decodingError(let typeName, let response, _):
+      return "Couldn't decode \(typeName) from Discord's response (HTTP \(response.status.code))."
+    case .appIdParameterRequired:
+      return "This request requires an application ID."
+    case .queryParametersMutuallyExclusive(let queries):
+      return "These request parameters can't be used together: \(queries.map(\.0).joined(separator: ", "))."
+    case .queryParameterOutOfBounds(let name, _, let lower, let upper):
+      return "The request parameter \(name) must be between \(lower) and \(upper)."
+    case .assertionFailureBotOnlyEndpoint:
+      return "This request is only available to bot accounts."
+    case .assertionFailureUserOnlyEndpoint:
+      return "This request is only available to user accounts."
+    }
+  }
+
+  public var errorUserInfo: [String: Any] {
+    var info: [String: Any] = [NSLocalizedDescriptionKey: errorDescription ?? "Discord request failed."]
+    if case .decodingError(_, _, let error) = self { info[NSUnderlyingErrorKey] = error }
+    return info
+  }
+}
+
+extension DiscordHTTPErrorResponse: LocalizedError {
+  public var errorDescription: String? {
+    switch self {
+    case .jsonError(let error): return error.detailedMessage
+    case .badStatusCode(let response): return "Discord request failed (HTTP \(response.status.code))."
+    }
+  }
+}

--- a/PaicordLib/Sources/DiscordHTTP/HTTPRateLimiter.swift
+++ b/PaicordLib/Sources/DiscordHTTP/HTTPRateLimiter.swift
@@ -68,11 +68,11 @@ actor HTTPRateLimiter {
   private var buckets: [String: Bucket] = [:]
 
   /// To take care of the global rate limit.
-  private var requestsThisSecond: (id: Int, count: Int) = (0, 0)
+  private var requestsThisSecond: (id: Int64, count: Int) = (0, 0)
 
   /// Only 10K invalid requests allowed each 10 minutes.
   /// We keep track of 500 / 1 minute so we can prevent hitting the limit easier.
-  private var invalidRequestsIn1Minute: (id: Int, count: Int) = (0, 0)
+  private var invalidRequestsIn1Minute: (id: Int64, count: Int) = (0, 0)
 
   /// Hitting the invalid requests limit will ban you for one day.
   /// Your code should be good enough not to send that many invalid requests.
@@ -83,12 +83,12 @@ actor HTTPRateLimiter {
     self.label = label
   }
 
-  private func currentGlobalRateLimitId() -> Int {
-    Int(Date().timeIntervalSince1970)
+  private func currentGlobalRateLimitId() -> Int64 {
+    Int64(Date().timeIntervalSince1970)
   }
 
-  private func currentMinutelyRateLimitId() -> Int {
-    Int(Date().timeIntervalSince1970) / 60
+  private func currentMinutelyRateLimitId() -> Int64 {
+    Int64(Date().timeIntervalSince1970) / 60
   }
 
   private func minutelyInvalidRequestsLimitAllows() -> Bool {
@@ -173,16 +173,12 @@ actor HTTPRateLimiter {
   @usableFromInline
   func shouldRequest(to endpoint: AnyEndpoint) -> ShouldRequest {
     guard minutelyInvalidRequestsLimitAllows() else { return .false }
-    if endpoint.countsAgainstGlobalRateLimit {
-      guard globalRateLimitAllows() else { return .false }
-    }
     if let bucketId = self.endpoints[endpoint.id],
       let bucket = self.buckets[bucketId]
     {
       switch bucket.shouldRequest() {
       case .true:
-        self.addGlobalRateLimitRecord()
-        return .true
+        break
       case .false:
         logger.warning(
           "Hit HTTP Bucket rate-limit",
@@ -198,9 +194,11 @@ actor HTTPRateLimiter {
         /// Also need to log necessary info to users, when e.g. we can't make the request.
         return .after(after)
       }
-    } else {
-      return .true
     }
+    if endpoint.countsAgainstGlobalRateLimit {
+      guard globalRateLimitAllows() else { return .false }
+    }
+    return .true
   }
 
   @usableFromInline

--- a/PaicordLib/Sources/DiscordModels/SuperProperties.swift
+++ b/PaicordLib/Sources/DiscordModels/SuperProperties.swift
@@ -421,19 +421,21 @@ public enum SuperProperties {
 
   public static func device_vendor_id() -> String? {
     #if os(iOS)
-      DispatchQueue.main.sync {
+      let readID = {
         if let uuid = UIDevice.current.identifierForVendor {
           return uuid.uuidString.uppercased()
         }
         return UUID().uuidString.uppercased()  // fallback
       }
+      return Thread.isMainThread ? readID() : DispatchQueue.main.sync(execute: readID)
     #elseif os(watchOS)
-      DispatchQueue.main.sync {
+      let readID = {
         if let uuid = WKInterfaceDevice.current().identifierForVendor {
           return uuid.uuidString.uppercased()
         }
         return UUID().uuidString.uppercased()  // fallback
       }
+      return Thread.isMainThread ? readID() : DispatchQueue.main.sync(execute: readID)
     #elseif os(macOS)
       return nil
     #else

--- a/PaicordLib/Sources/DiscordModels/SuperProperties.swift
+++ b/PaicordLib/Sources/DiscordModels/SuperProperties.swift
@@ -377,9 +377,7 @@ public enum SuperProperties {
   }
 
   public static func cfnetwork_version() -> String {
-    let dictionary = Bundle(identifier: "com.apple.CFNetwork")?.infoDictionary!
-    let version = dictionary?["CFBundleShortVersionString"] as! String
-    return version
+    Bundle(identifier: "com.apple.CFNetwork")?.infoDictionary?["CFBundleShortVersionString"] as? String ?? "0"
   }
 
   #if os(iOS) || os(macOS) || os(tvOS) || os(watchOS) || os(visionOS)

--- a/PaicordLib/Sources/DiscordModels/Types/Application Commands.swift
+++ b/PaicordLib/Sources/DiscordModels/Types/Application Commands.swift
@@ -7,7 +7,7 @@ public struct ApplicationCommand: Sendable, Codable {
   #if Non64BitSystemsCompatibility
     @UnstableEnum<UInt64>
   #else
-    @UnstableEnum<UInt>
+    @UnstableEnum<UInt64>
   #endif
   public enum Kind: Sendable, Codable {
     case chatInput  // 1
@@ -17,7 +17,7 @@ public struct ApplicationCommand: Sendable, Codable {
     #if Non64BitSystemsCompatibility
       case __undocumented(UInt64)
     #else
-      case __undocumented(UInt)
+      case __undocumented(UInt64)
     #endif
   }
 
@@ -28,7 +28,7 @@ public struct ApplicationCommand: Sendable, Codable {
     #if Non64BitSystemsCompatibility
       @UnstableEnum<UInt64>
     #else
-      @UnstableEnum<UInt>
+      @UnstableEnum<UInt64>
     #endif
     public enum Kind: Sendable, Codable {
       case subCommand  // 1
@@ -46,7 +46,7 @@ public struct ApplicationCommand: Sendable, Codable {
       #if Non64BitSystemsCompatibility
         case __undocumented(UInt64)
       #else
-        case __undocumented(UInt)
+        case __undocumented(UInt64)
       #endif
     }
 

--- a/PaicordLib/Sources/DiscordModels/Types/Application.swift
+++ b/PaicordLib/Sources/DiscordModels/Types/Application.swift
@@ -5,7 +5,7 @@ public struct DiscordApplication: Sendable, Codable {
   #if Non64BitSystemsCompatibility
     @UnstableEnum<UInt64>
   #else
-    @UnstableEnum<UInt>
+    @UnstableEnum<UInt64>
   #endif
   public enum Flag: Sendable {
     case applicationAutoModerationRuleCreateBadge  // 6
@@ -22,7 +22,7 @@ public struct DiscordApplication: Sendable, Codable {
     #if Non64BitSystemsCompatibility
       case __undocumented(UInt64)
     #else
-      case __undocumented(UInt)
+      case __undocumented(UInt64)
     #endif
   }
 
@@ -106,7 +106,7 @@ public struct DiscordApplication: Sendable, Codable {
     #if Non64BitSystemsCompatibility
       @UnstableEnum<UInt64>
     #else
-      @UnstableEnum<UInt>
+      @UnstableEnum<UInt64>
     #endif
     public enum Kind: Sendable, Codable {
       case one  // 1
@@ -115,7 +115,7 @@ public struct DiscordApplication: Sendable, Codable {
       #if Non64BitSystemsCompatibility
         case __undocumented(UInt64)
       #else
-        case __undocumented(UInt)
+        case __undocumented(UInt64)
       #endif
     }
   }
@@ -186,7 +186,7 @@ public struct EmbeddedActivities: Sendable, Codable, Equatable, Hashable {
     #if Non64BitSystemsCompatibility
       @UnstableEnum<UInt64>
     #else
-      @UnstableEnum<UInt>
+      @UnstableEnum<UInt64>
     #endif
     public enum OrientationLockState: Sendable, Codable {
       case unlocked  // 0
@@ -196,7 +196,7 @@ public struct EmbeddedActivities: Sendable, Codable, Equatable, Hashable {
       #if Non64BitSystemsCompatibility
         case __undocumented(UInt64)
       #else
-        case __undocumented(UInt)
+        case __undocumented(UInt64)
       #endif
     }
 
@@ -209,7 +209,7 @@ public struct EmbeddedActivities: Sendable, Codable, Equatable, Hashable {
       #if Non64BitSystemsCompatibility
         @UnstableEnum<UInt64>
       #else
-        @UnstableEnum<UInt>
+        @UnstableEnum<UInt64>
       #endif
       public enum LabelType: Sendable, Codable {
         case none  // 0
@@ -219,7 +219,7 @@ public struct EmbeddedActivities: Sendable, Codable, Equatable, Hashable {
         #if Non64BitSystemsCompatibility
           case __undocumented(UInt64)
         #else
-          case __undocumented(UInt)
+          case __undocumented(UInt64)
         #endif
       }
 

--- a/PaicordLib/Sources/DiscordModels/Types/Audit Log.swift
+++ b/PaicordLib/Sources/DiscordModels/Types/Audit Log.swift
@@ -6,7 +6,7 @@ public struct AuditLog: Sendable, Codable {
 
     public enum Mixed: Sendable, Codable, CustomStringConvertible {
       case string(String)
-      case int(Int)
+      case int(Int64)
       case double(Double)
       case bool(Bool)
       case strings([String])
@@ -50,7 +50,7 @@ public struct AuditLog: Sendable, Codable {
         let container = try decoder.singleValueContainer()
         if let string = try? container.decode(String.self) {
           self = .string(string)
-        } else if let int = try? container.decode(Int.self) {
+        } else if let int = try? container.decode(Int64.self) {
           self = .int(int)
         } else if let bool = try? container.decode(Bool.self) {
           self = .bool(bool)

--- a/PaicordLib/Sources/DiscordModels/Types/BitField.swift
+++ b/PaicordLib/Sources/DiscordModels/Types/BitField.swift
@@ -1,7 +1,7 @@
-public protocol BitField: OptionSet, Hashable, CustomStringConvertible where RawValue == UInt {
+public protocol BitField: OptionSet, Hashable, CustomStringConvertible where RawValue == UInt64 {
   associatedtype R: RawRepresentable & LosslessRawRepresentable
-  where R: Hashable, R.RawValue == UInt
-  var rawValue: UInt { get set }
+  where R: Hashable, R.RawValue == UInt64
+  var rawValue: UInt64 { get set }
 }
 
 extension BitField {
@@ -49,7 +49,7 @@ extension BitField {
   public func representableValues() -> Set<R> {
     var bitValue = self.rawValue
     var values: [R] = []
-    var counter: UInt = 0
+    var counter: UInt64 = 0
     while bitValue != 0 {
       if (bitValue & 1) == 1 {
         /// `R` is ``LosslessRawRepresentable``. Safe to force-unwrap.
@@ -82,17 +82,17 @@ extension BitField {
 
 /// A bit-field that decode/encodes itself as an integer.
 public struct IntBitField<R>: BitField
-where R: RawRepresentable & LosslessRawRepresentable & Hashable, R.RawValue == UInt {
-  public var rawValue: UInt
+where R: RawRepresentable & LosslessRawRepresentable & Hashable, R.RawValue == UInt64 {
+  public var rawValue: UInt64
 
-  public init(rawValue: UInt = 0) {
+  public init(rawValue: UInt64 = 0) {
     self.rawValue = rawValue
   }
 }
 
 extension IntBitField: Codable {
   public init(from decoder: any Decoder) throws {
-    self.rawValue = try UInt(from: decoder)
+    self.rawValue = try UInt64(from: decoder)
   }
 
   public func encode(to encoder: any Encoder) throws {
@@ -104,10 +104,10 @@ extension IntBitField: Sendable where R: Sendable {}
 
 /// A bit-field that decode/encodes itself as a string.
 public struct StringBitField<R>: BitField
-where R: RawRepresentable & LosslessRawRepresentable & Hashable, R.RawValue == UInt {
-  public var rawValue: UInt
+where R: RawRepresentable & LosslessRawRepresentable & Hashable, R.RawValue == UInt64 {
+  public var rawValue: UInt64
 
-  public init(rawValue: UInt = 0) {
+  public init(rawValue: UInt64 = 0) {
     self.rawValue = rawValue
   }
 }
@@ -128,7 +128,7 @@ extension StringBitField: Codable {
 
   public init(from decoder: any Decoder) throws {
     let string = try String(from: decoder)
-    guard let int = UInt(string) else {
+    guard let int = UInt64(string) else {
       throw DecodingError.notRepresentingUInt(string)
     }
     self.rawValue = int

--- a/PaicordLib/Sources/DiscordModels/Types/BitField.swift
+++ b/PaicordLib/Sources/DiscordModels/Types/BitField.swift
@@ -127,9 +127,10 @@ extension StringBitField: Codable {
   }
 
   public init(from decoder: any Decoder) throws {
-    let string = try String(from: decoder)
+    let container = try decoder.singleValueContainer()
+    let string = try container.decode(String.self)
     guard let int = UInt64(string) else {
-      throw DecodingError.notRepresentingUInt(string)
+      throw Swift.DecodingError.dataCorruptedError(in: container, debugDescription: "Expected an unsigned 64-bit permission value, received \(string).")
     }
     self.rawValue = int
   }

--- a/PaicordLib/Sources/DiscordModels/Types/Channel.swift
+++ b/PaicordLib/Sources/DiscordModels/Types/Channel.swift
@@ -221,7 +221,7 @@ public struct DiscordChannel: Sendable, Codable, Equatable, Hashable {
   public var available_tags: [ForumTag]?
   public var template: String?
   public var member_ids_preview: [String]?
-  public var version: Int?
+  public var version: Int64?
   /// Thread-only:
   public var member: ThreadMember?
   public var newly_created: Bool?
@@ -334,6 +334,17 @@ extension DiscordChannel {
       public var channel_id: ChannelSnowflake?
       public var guild_id: GuildSnowflake?
       public var fail_if_not_exists: Bool?
+
+      private enum CodingKeys: String, CodingKey { case type, message_id, channel_id, guild_id, fail_if_not_exists }
+      public init(from decoder: any Decoder) throws {
+        let values = try decoder.container(keyedBy: CodingKeys.self)
+        type = try values.decodeIfPresent(Kind.self, forKey: .type) ?? .reply
+        message_id = try values.decodeIfPresent(MessageSnowflake.self, forKey: .message_id)
+        channel_id = try values.decodeIfPresent(ChannelSnowflake.self, forKey: .channel_id)
+        guild_id = try values.decodeIfPresent(GuildSnowflake.self, forKey: .guild_id)
+        fail_if_not_exists = try values.decodeIfPresent(Bool.self, forKey: .fail_if_not_exists)
+      }
+
 
       public init(
         type: Kind,

--- a/PaicordLib/Sources/DiscordModels/Types/Channel.swift
+++ b/PaicordLib/Sources/DiscordModels/Types/Channel.swift
@@ -97,7 +97,7 @@ public struct DiscordChannel: Sendable, Codable, Equatable, Hashable {
   #if Non64BitSystemsCompatibility
     @UnstableEnum<UInt64>
   #else
-    @UnstableEnum<UInt>
+    @UnstableEnum<UInt64>
   #endif
   public enum Flag: Sendable {
     case guildFeedRemoved  // 0
@@ -119,7 +119,7 @@ public struct DiscordChannel: Sendable, Codable, Equatable, Hashable {
     #if Non64BitSystemsCompatibility
       case __undocumented(UInt64)
     #else
-      case __undocumented(UInt)
+      case __undocumented(UInt64)
     #endif
   }
 
@@ -426,7 +426,7 @@ extension DiscordChannel {
     #if Non64BitSystemsCompatibility
       @UnstableEnum<UInt64>
     #else
-      @UnstableEnum<UInt>
+      @UnstableEnum<UInt64>
     #endif
     public enum Flag: Sendable {
       case crossposted  // 0
@@ -446,7 +446,7 @@ extension DiscordChannel {
       #if Non64BitSystemsCompatibility
         case __undocumented(UInt64)
       #else
-        case __undocumented(UInt)
+        case __undocumented(UInt64)
       #endif
     }
 
@@ -501,7 +501,7 @@ extension DiscordChannel {
       #if Non64BitSystemsCompatibility
         @UnstableEnum<UInt64>
       #else
-        @UnstableEnum<UInt>
+        @UnstableEnum<UInt64>
       #endif
       public enum Flag: Sendable {
         case isRemix  // 2
@@ -509,7 +509,7 @@ extension DiscordChannel {
         #if Non64BitSystemsCompatibility
           case __undocumented(UInt64)
         #else
-          case __undocumented(UInt)
+          case __undocumented(UInt64)
         #endif
       }
 
@@ -878,7 +878,7 @@ public struct ThreadMember: Sendable, Codable, Equatable, Hashable {
   #if Non64BitSystemsCompatibility
     @UnstableEnum<UInt64>
   #else
-    @UnstableEnum<UInt>
+    @UnstableEnum<UInt64>
   #endif
   public enum Flag: Sendable {
     case hasInteracted  // 0
@@ -889,7 +889,7 @@ public struct ThreadMember: Sendable, Codable, Equatable, Hashable {
     #if Non64BitSystemsCompatibility
       case __undocumented(UInt64)
     #else
-      case __undocumented(UInt)
+      case __undocumented(UInt64)
     #endif
   }
 }
@@ -1252,7 +1252,7 @@ public struct ConversationSummary: Sendable, Codable {
   #if Non64BitSystemsCompatibility
     @UnstableEnum<UInt64>
   #else
-    @UnstableEnum<UInt>
+    @UnstableEnum<UInt64>
   #endif
   public enum Source: Sendable, Codable {
     case source0  // 0
@@ -1262,14 +1262,14 @@ public struct ConversationSummary: Sendable, Codable {
     #if Non64BitSystemsCompatibility
       case __undocumented(UInt64)
     #else
-      case __undocumented(UInt)
+      case __undocumented(UInt64)
     #endif
   }
 
   #if Non64BitSystemsCompatibility
     @UnstableEnum<UInt64>
   #else
-    @UnstableEnum<UInt>
+    @UnstableEnum<UInt64>
   #endif
   public enum Kind: Sendable, Codable {
     case unset  // 0
@@ -1280,7 +1280,7 @@ public struct ConversationSummary: Sendable, Codable {
     #if Non64BitSystemsCompatibility
       case __undocumented(UInt64)
     #else
-      case __undocumented(UInt)
+      case __undocumented(UInt64)
     #endif
   }
 }

--- a/PaicordLib/Sources/DiscordModels/Types/Emoji.swift
+++ b/PaicordLib/Sources/DiscordModels/Types/Emoji.swift
@@ -12,7 +12,7 @@ public struct Emoji: Sendable, Codable, Equatable, Hashable {
   public var managed: Bool?
   public var animated: Bool?
   public var available: Bool?
-  public var version: Int?
+  public var version: Int64?
 
   public init(
     id: EmojiSnowflake? = nil,
@@ -23,7 +23,7 @@ public struct Emoji: Sendable, Codable, Equatable, Hashable {
     managed: Bool? = nil,
     animated: Bool? = nil,
     available: Bool? = nil,
-    version: Int? = nil
+    version: Int64? = nil
   ) {
     self.id = id
     self.name = name

--- a/PaicordLib/Sources/DiscordModels/Types/Error Codes.swift
+++ b/PaicordLib/Sources/DiscordModels/Types/Error Codes.swift
@@ -309,22 +309,13 @@ public struct JSONError: Sendable, Codable {
       var fieldErrors: [String: [FieldError]] = [:]
 
       for key in container.allKeys {
-        // get errors for each field
-        do {
-          let fieldContainer = try container.nestedContainer(
-            keyedBy: DynamicCodingKeys.self,
-            forKey: key
-          )
-          let errorsArray = try fieldContainer.decodeIfPresent(
-            [FieldError].self,
-            forKey: DynamicCodingKeys(stringValue: "_errors")!
-          )
-          fieldErrors[key.stringValue] = errorsArray ?? []
-        } catch {
-          print(
-            "Failed to decode field errors for key \(key.stringValue): \(error)"
-          )
-          fieldErrors[key.stringValue] = []
+        if key.stringValue == "_errors" {
+          fieldErrors["$"] = try container.decode([FieldError].self, forKey: key)
+        } else {
+          let nested = try container.decode(Errors.self, forKey: key)
+          for (path, errors) in nested.fieldErrors {
+            fieldErrors[path == "$" ? key.stringValue : "\(key.stringValue).\(path)"] = errors
+          }
         }
       }
 
@@ -340,6 +331,19 @@ public struct JSONError: Sendable, Codable {
     }
   }
 
+  public var detailedMessage: String {
+    var lines = [message]
+    if let code { lines.append("Discord \(code.rawValue)") }
+    if let errors {
+      for path in errors.fieldErrors.keys.sorted() {
+        for error in errors.fieldErrors[path] ?? [] {
+          lines.append("\(path): \(error.message) (\(error.code))")
+        }
+      }
+    }
+    return lines.joined(separator: "\n")
+  }
+
   public init(from decoder: any Decoder) throws {
     let container = try decoder.container(keyedBy: CodingKeys.self)
     self.message = try container.decode(String.self, forKey: .message)
@@ -349,13 +353,7 @@ public struct JSONError: Sendable, Codable {
       forKey: .mfa
     )
 
-    do {
-      self.errors = try container.decodeIfPresent(Errors.self, forKey: .errors)
-    } catch {
-      print("Failed to decode errors: \(error)")
-      // this isnt critical and i'd rather not fail decoding the entire error
-      self.errors = nil
-    }
+    self.errors = try? container.decodeIfPresent(Errors.self, forKey: .errors)
   }
 
   enum CodingKeys: String, CodingKey {

--- a/PaicordLib/Sources/DiscordModels/Types/Gateway+Payloads.swift
+++ b/PaicordLib/Sources/DiscordModels/Types/Gateway+Payloads.swift
@@ -589,7 +589,7 @@ extension Gateway {
     public var nsfw: Bool
     public var application_command_counts: [String: Int]?
     public var embedded_activities: [Gateway.Activity]?
-    public var version: Int?
+    public var version: Int64?
     public var guild_id: GuildSnowflake?
     /// Extra fields:
     public var joined_at: DiscordTimestamp
@@ -807,7 +807,7 @@ extension Gateway {
   public struct GuildRoleDelete: Sendable, Codable {
     public var guild_id: GuildSnowflake
     public var role_id: RoleSnowflake
-    public var version: Int?
+    public var version: Int64?
   }
 
   /// Not the same as what Discord calls `Guild Scheduled Event User`.
@@ -2047,14 +2047,14 @@ extension Gateway {
     public var mention_count: Int?
     public var flags: IntBitField<ReadState.Flags>?
     public var last_viewed: Int?
-    public var version: Int
+    public var version: Int64
   }
 
   /// https://docs.discord.food/topics/gateway-events#channel-pins-ack
   public struct ChannelPinsAcknowledge: Sendable, Codable {
     public var channel_id: ChannelSnowflake
     public var timestamp: DiscordTimestamp
-    public var version: Int
+    public var version: Int64
   }
 
   /// https://docs.discord.food/topics/gateway-events#user-non-channel-ack-structure
@@ -2062,7 +2062,7 @@ extension Gateway {
     public var ack_type: ReadState.Kind
     public var resource_id: UserSnowflake
     public var entity_id: AnySnowflake
-    public var version: Int
+    public var version: Int64
   }
 
   /// https://docs.discord.food/resources/message#create-attachments

--- a/PaicordLib/Sources/DiscordModels/Types/Gateway+Payloads.swift
+++ b/PaicordLib/Sources/DiscordModels/Types/Gateway+Payloads.swift
@@ -2138,6 +2138,7 @@ extension Gateway {
       public var threads: Bool?
       public var member_updates: Bool?
 
+      public var members: [UserSnowflake]?
       public var channels: [ChannelSnowflake: [IntPair]]?
       public var thread_member_lists: [ChannelSnowflake]?
 
@@ -2146,12 +2147,14 @@ extension Gateway {
         activities: Bool? = nil,
         threads: Bool? = nil,
         member_updates: Bool? = nil,
+        members: [UserSnowflake]? = nil,
         channels: [ChannelSnowflake: [IntPair]]? = nil,
         thread_member_lists: [ChannelSnowflake]? = nil
       ) {
         self.typing = typing
         self.activities = activities
         self.threads = threads
+        self.members = members
         self.channels = channels
         self.member_updates = member_updates
         self.thread_member_lists = thread_member_lists

--- a/PaicordLib/Sources/DiscordModels/Types/Gateway+Payloads.swift
+++ b/PaicordLib/Sources/DiscordModels/Types/Gateway+Payloads.swift
@@ -215,7 +215,7 @@ extension Gateway {
 
     /// https://discord.com/developers/docs/topics/gateway-events#update-presence-gateway-presence-update-structure
     public struct Presence: Sendable, Codable {
-      public var since: Int?
+      public var since: Int64?
       public var activities: [Activity]
       public var status: Status
       public var afk: Bool
@@ -226,7 +226,7 @@ extension Gateway {
         status: Status,
         afk: Bool
       ) {
-        self.since = since == nil ? nil : Int(since!.timeIntervalSince1970)
+        self.since = since.map { Int64($0.timeIntervalSince1970 * 1000) }
         self.activities = activities
         self.status = status
         self.afk = afk
@@ -324,7 +324,7 @@ extension Gateway {
   #if Non64BitSystemsCompatibility
     @UnstableEnum<UInt64>
   #else
-    @UnstableEnum<UInt>
+    @UnstableEnum<UInt64>
   #endif
   public enum Intent: Sendable, Codable, CaseIterable {
     case guilds  // 0
@@ -352,7 +352,7 @@ extension Gateway {
     #if Non64BitSystemsCompatibility
       case __undocumented(UInt64)
     #else
-      case __undocumented(UInt)
+      case __undocumented(UInt64)
     #endif
   }
 
@@ -360,7 +360,7 @@ extension Gateway {
   #if Non64BitSystemsCompatibility
     @UnstableEnum<UInt64>
   #else
-    @UnstableEnum<UInt>
+    @UnstableEnum<UInt64>
   #endif
   public enum Capability: Sendable, Codable, CaseIterable {
     case lazyUserNotes  // 0
@@ -383,7 +383,7 @@ extension Gateway {
     #if Non64BitSystemsCompatibility
       case __undocumented(UInt64)
     #else
-      case __undocumented(UInt)
+      case __undocumented(UInt64)
     #endif
   }
 
@@ -419,7 +419,7 @@ extension Gateway {
   /// https://docs.discord.food/topics/gateway-events#update-time-spent-session-id
   public struct UpdateTimeSpentSessionID: Sendable, Codable {
     // Unix timestamp (in milliseconds) of when the session ID was generated
-    public var initialization_timestamp: Int = Int(
+    public var initialization_timestamp: Int64 = Int64(
       SuperProperties._initialisation_date.timeIntervalSince1970 * 1000
     )
     // A client-generated UUID, same as client_heartbeat_session_id in client properties
@@ -1257,10 +1257,10 @@ extension Gateway {
 
     /// https://discord.com/developers/docs/topics/gateway-events#activity-object-activity-timestamps
     public struct Timestamps: Sendable, Codable, Equatable, Hashable {
-      public var start: Int?
-      public var end: Int?
+      public var start: Int64?
+      public var end: Int64?
 
-      public init(start: Int? = nil, end: Int? = nil) {
+      public init(start: Int64? = nil, end: Int64? = nil) {
         self.start = start
         self.end = end
       }
@@ -1335,7 +1335,7 @@ extension Gateway {
     #if Non64BitSystemsCompatibility
       @UnstableEnum<UInt64>
     #else
-      @UnstableEnum<UInt>
+      @UnstableEnum<UInt64>
     #endif
     public enum Flag: Sendable {
       case instance  // 0
@@ -1351,7 +1351,7 @@ extension Gateway {
       #if Non64BitSystemsCompatibility
         case __undocumented(UInt64)
       #else
-        case __undocumented(UInt)
+        case __undocumented(UInt64)
       #endif
     }
 
@@ -1379,7 +1379,7 @@ extension Gateway {
     public var name: String?
     public var type: Kind?
     public var url: String?
-    public var created_at: Int?
+    public var created_at: Int64?
     public var timestamps: Timestamps?
     public var application_id: ApplicationSnowflake?
     public var details: String?
@@ -1398,7 +1398,7 @@ extension Gateway {
       self.type = try container.decodeIfPresent(Kind.self, forKey: .type)
       self.url = try container.decodeIfPresent(String.self, forKey: .url)
       self.created_at = try container.decodeIfPresent(
-        Int.self,
+        Int64.self,
         forKey: .created_at
       )
       self.timestamps = try container.decodeIfPresent(
@@ -1441,7 +1441,7 @@ extension Gateway {
         )
       } catch let error as DecodingError {
         if case .typeMismatch = error {
-          let number = try container.decode(Int.self, forKey: .application_id)
+          let number = try container.decode(UInt64.self, forKey: .application_id)
           self.application_id = .init("\(number)")
         } else {
           throw error
@@ -1478,7 +1478,7 @@ extension Gateway {
     public var channel_id: ChannelSnowflake
     public var guild_id: GuildSnowflake?
     public var user_id: UserSnowflake
-    public var timestamp: Int
+    public var timestamp: Int64
     public var member: Guild.Member?
   }
 
@@ -1619,7 +1619,7 @@ extension Gateway {
     #if Non64BitSystemsCompatibility
       @UnstableEnum<UInt64>
     #else
-      @UnstableEnum<UInt>
+      @UnstableEnum<UInt64>
     #endif
     public enum Reason: Sendable, Codable {
       case unknown  // 1
@@ -1646,7 +1646,7 @@ extension Gateway {
       #if Non64BitSystemsCompatibility
         case __undocumented(UInt64)
       #else
-        case __undocumented(UInt)
+        case __undocumented(UInt64)
       #endif
     }
   }
@@ -1688,7 +1688,7 @@ extension Gateway {
     #if Non64BitSystemsCompatibility
       @UnstableEnum<UInt64>
     #else
-      @UnstableEnum<UInt>
+      @UnstableEnum<UInt64>
     #endif
     public enum ModalSize: Sendable, Codable {
       case small  // 1
@@ -1698,7 +1698,7 @@ extension Gateway {
       #if Non64BitSystemsCompatibility
         case __undocumented(UInt64)
       #else
-        case __undocumented(UInt)
+        case __undocumented(UInt64)
       #endif
     }
   }
@@ -1721,7 +1721,7 @@ extension Gateway {
     #if Non64BitSystemsCompatibility
       @UnstableEnum<UInt64>
     #else
-      @UnstableEnum<UInt>
+      @UnstableEnum<UInt64>
     #endif
     public enum Flag: Sendable {
       case useNewNotifications  // 4
@@ -1730,7 +1730,7 @@ extension Gateway {
       #if Non64BitSystemsCompatibility
         case __undocumented(UInt64)
       #else
-        case __undocumented(UInt)
+        case __undocumented(UInt64)
       #endif
     }
   }
@@ -1916,7 +1916,7 @@ extension Gateway {
     #if Non64BitSystemsCompatibility
       @UnstableEnum<UInt64>
     #else
-      @UnstableEnum<UInt>
+      @UnstableEnum<UInt64>
     #endif
     public enum Kind: Sendable, Codable {
       case preloaded  // 1
@@ -1925,7 +1925,7 @@ extension Gateway {
       #if Non64BitSystemsCompatibility
         case __undocumented(UInt64)
       #else
-        case __undocumented(UInt)
+        case __undocumented(UInt64)
       #endif
     }
   }
@@ -2003,7 +2003,7 @@ extension Gateway {
     #if Non64BitSystemsCompatibility
       @UnstableEnum<UInt64>
     #else
-      @UnstableEnum<UInt>
+      @UnstableEnum<UInt64>
     #endif
     public enum Kind: Sendable, Codable {
       case channel  // 0
@@ -2016,14 +2016,14 @@ extension Gateway {
       #if Non64BitSystemsCompatibility
         case __undocumented(UInt64)
       #else
-        case __undocumented(UInt)
+        case __undocumented(UInt64)
       #endif
     }
 
     #if Non64BitSystemsCompatibility
       @UnstableEnum<UInt64>
     #else
-      @UnstableEnum<UInt>
+      @UnstableEnum<UInt64>
     #endif
     public enum Flags: Sendable, Codable {
       case isGuildChannel  // 0
@@ -2033,7 +2033,7 @@ extension Gateway {
       #if Non64BitSystemsCompatibility
         case __undocumented(UInt64)
       #else
-        case __undocumented(UInt)
+        case __undocumented(UInt64)
       #endif
     }
   }

--- a/PaicordLib/Sources/DiscordModels/Types/Gateway.swift
+++ b/PaicordLib/Sources/DiscordModels/Types/Gateway.swift
@@ -471,8 +471,11 @@ public struct Gateway: Sendable, Codable {
       }
 
       switch opcode {
-      case .heartbeat, .heartbeatAccepted, .reconnect:
-        guard try container.decodeNil(forKey: .data) else {
+      case .heartbeat:
+        _ = try container.decodeIfPresent(Int.self, forKey: .data)
+        self.data = nil
+      case .heartbeatAccepted, .reconnect:
+        guard try !container.contains(.data) || container.decodeNil(forKey: .data) else {
           throw DecodingError.typeMismatch(
             Optional<Never>.self,
             .init(

--- a/PaicordLib/Sources/DiscordModels/Types/Guild Template.swift
+++ b/PaicordLib/Sources/DiscordModels/Types/Guild Template.swift
@@ -21,7 +21,7 @@ public struct GuildTemplate: Codable, Sendable {
     public var managed: Bool?
     public var mentionable: Bool
     public var tags: DiscordModels.Role.Tags?
-    public var version: Int?
+    public var version: Int64?
   }
 
   /// https://discord.com/developers/docs/resources/guild#guild-object-guild-structure
@@ -75,7 +75,7 @@ public struct GuildTemplate: Codable, Sendable {
     public var nsfw: Bool?
     public var application_command_counts: [String: Int]?
     public var embedded_activities: [Gateway.Activity]?
-    public var version: Int?
+    public var version: Int64?
     public var guild_id: GuildSnowflake?
   }
 

--- a/PaicordLib/Sources/DiscordModels/Types/Guild.swift
+++ b/PaicordLib/Sources/DiscordModels/Types/Guild.swift
@@ -51,7 +51,7 @@ public struct Guild: Sendable, Codable, Hashable, Equatable, Identifiable {
     application_command_counts: [String: Int]? = nil,
     embedded_activities: [Gateway.Activity]? = nil,
     members: [Guild.Member]? = nil,
-    version: Int? = nil,
+    version: Int64? = nil,
     guild_id: GuildSnowflake? = nil
   ) {
     self.id = id
@@ -474,6 +474,7 @@ public struct Guild: Sendable, Codable, Hashable, Equatable, Identifiable {
   public var owner: Bool?
   public var owner_id: UserSnowflake
   public var channels: [DiscordChannel]?
+  public var threads: [DiscordChannel]?
   public var permissions: StringBitField<Permission>?
   public var afk_channel_id: ChannelSnowflake?
   public var afk_timeout: AFKTimeout
@@ -515,7 +516,7 @@ public struct Guild: Sendable, Codable, Hashable, Equatable, Identifiable {
   public var application_command_counts: [String: Int]?
   public var embedded_activities: [Gateway.Activity]?
   public var members: [Guild.Member]?
-  public var version: Int?
+  public var version: Int64?
   public var guild_id: GuildSnowflake?
 }
 
@@ -569,7 +570,7 @@ public struct PartialGuild: Sendable, Codable, Equatable, Hashable {
   public var nsfw: Bool?
   public var application_command_counts: [String: Int]?
   public var embedded_activities: [Gateway.Activity]?
-  public var version: Int?
+  public var version: Int64?
   public var guild_id: GuildSnowflake?
 }
 
@@ -782,7 +783,7 @@ extension Guild {
     public var notify_highlights: Int
     public var suppress_everyone: Bool
     public var suppress_roles: Bool
-    public var version: Int
+    public var version: Int64
 
     /// https://docs.discord.food/resources/user-settings#partial-user-guild-settings-structure
     public struct Partial: Sendable, Codable {

--- a/PaicordLib/Sources/DiscordModels/Types/Guild.swift
+++ b/PaicordLib/Sources/DiscordModels/Types/Guild.swift
@@ -113,7 +113,7 @@ public struct Guild: Sendable, Codable, Hashable, Equatable, Identifiable {
     #if Non64BitSystemsCompatibility
       @UnstableEnum<UInt64>
     #else
-      @UnstableEnum<UInt>
+      @UnstableEnum<UInt64>
     #endif
     public enum Flag: Sendable {
       case didRejoin  // 0
@@ -129,7 +129,7 @@ public struct Guild: Sendable, Codable, Hashable, Equatable, Identifiable {
       #if Non64BitSystemsCompatibility
         case __undocumented(UInt64)
       #else
-        case __undocumented(UInt)
+        case __undocumented(UInt64)
       #endif
     }
 
@@ -366,7 +366,7 @@ public struct Guild: Sendable, Codable, Hashable, Equatable, Identifiable {
   #if Non64BitSystemsCompatibility
     @UnstableEnum<UInt64>
   #else
-    @UnstableEnum<UInt>
+    @UnstableEnum<UInt64>
   #endif
   public enum SystemChannelFlag: Sendable {
     case suppressJoinNotifications  // 0
@@ -379,7 +379,7 @@ public struct Guild: Sendable, Codable, Hashable, Equatable, Identifiable {
     #if Non64BitSystemsCompatibility
       case __undocumented(UInt64)
     #else
-      case __undocumented(UInt)
+      case __undocumented(UInt64)
     #endif
   }
 
@@ -813,7 +813,7 @@ extension Guild {
       #if Non64BitSystemsCompatibility
         @UnstableEnum<UInt64>
       #else
-        @UnstableEnum<UInt>
+        @UnstableEnum<UInt64>
       #endif
       public enum Flag: Sendable {
         case unreadsOnlyMentions  // 9
@@ -826,14 +826,14 @@ extension Guild {
         #if Non64BitSystemsCompatibility
           case __undocumented(UInt64)
         #else
-          case __undocumented(UInt)
+          case __undocumented(UInt64)
         #endif
       }
 
       #if Non64BitSystemsCompatibility
         @UnstableEnum<UInt64>
       #else
-        @UnstableEnum<UInt>
+        @UnstableEnum<UInt64>
       #endif
       public enum MessageNotifications: Sendable, Codable {
         case allMessages  // 0
@@ -844,7 +844,7 @@ extension Guild {
         #if Non64BitSystemsCompatibility
           case __undocumented(UInt64)
         #else
-          case __undocumented(UInt)
+          case __undocumented(UInt64)
         #endif
       }
     }
@@ -852,7 +852,7 @@ extension Guild {
     #if Non64BitSystemsCompatibility
       @UnstableEnum<UInt64>
     #else
-      @UnstableEnum<UInt>
+      @UnstableEnum<UInt64>
     #endif
     public enum Flag: Sendable {
       case unreadsAllMessages  // 11
@@ -863,7 +863,7 @@ extension Guild {
       #if Non64BitSystemsCompatibility
         case __undocumented(UInt64)
       #else
-        case __undocumented(UInt)
+        case __undocumented(UInt64)
       #endif
     }
 

--- a/PaicordLib/Sources/DiscordModels/Types/Permission.swift
+++ b/PaicordLib/Sources/DiscordModels/Types/Permission.swift
@@ -104,6 +104,6 @@ public struct Role: Sendable, Codable, Equatable, Hashable {
   public var managed: Bool
   public var mentionable: Bool
   public var tags: Tags?
-  public var version: Int?
+  public var version: Int64?
   public var flags: IntBitField<Flag>
 }

--- a/PaicordLib/Sources/DiscordModels/Types/Permission.swift
+++ b/PaicordLib/Sources/DiscordModels/Types/Permission.swift
@@ -3,7 +3,7 @@
 #if Non64BitSystemsCompatibility
   @UnstableEnum<UInt64>
 #else
-  @UnstableEnum<UInt>
+  @UnstableEnum<UInt64>
 #endif
 public enum Permission: Sendable, Codable {
   case createInstantInvite  // 0
@@ -57,7 +57,7 @@ public enum Permission: Sendable, Codable {
   case sendPolls  // 49
   case useExternalApps  // 50
   case pinMessages  // 51
-  case __undocumented(UInt)
+  case __undocumented(UInt64)
 }
 
 /// https://discord.com/developers/docs/topics/permissions#role-object
@@ -80,7 +80,7 @@ public struct Role: Sendable, Codable, Equatable, Hashable {
   #if Non64BitSystemsCompatibility
     @UnstableEnum<UInt64>
   #else
-    @UnstableEnum<UInt>
+    @UnstableEnum<UInt64>
   #endif
   public enum Flag: Sendable {
     case inPrompt  // 0
@@ -88,7 +88,7 @@ public struct Role: Sendable, Codable, Equatable, Hashable {
     #if Non64BitSystemsCompatibility
       case __undocumented(UInt64)
     #else
-      case __undocumented(UInt)
+      case __undocumented(UInt64)
     #endif
   }
 

--- a/PaicordLib/Sources/DiscordModels/Types/Relationship.swift
+++ b/PaicordLib/Sources/DiscordModels/Types/Relationship.swift
@@ -70,7 +70,7 @@ public struct FriendSuggestion: Sendable, Codable {
     #if Non64BitSystemsCompatibility
       @UnstableEnum<UInt64>
     #else
-      @UnstableEnum<UInt>
+      @UnstableEnum<UInt64>
     #endif
     public enum Kind: Sendable, Codable {
       case externalFriend  // 1
@@ -78,7 +78,7 @@ public struct FriendSuggestion: Sendable, Codable {
       #if Non64BitSystemsCompatibility
         case __undocumented(UInt64)
       #else
-        case __undocumented(UInt)
+        case __undocumented(UInt64)
       #endif
     }
   }

--- a/PaicordLib/Sources/DiscordModels/Types/SKU.swift
+++ b/PaicordLib/Sources/DiscordModels/Types/SKU.swift
@@ -23,7 +23,7 @@ public struct SKU: Sendable, Codable {
   #if Non64BitSystemsCompatibility
     @UnstableEnum<UInt64>
   #else
-    @UnstableEnum<UInt>
+    @UnstableEnum<UInt64>
   #endif
   public enum Flag: Sendable {
     case available  // 2
@@ -33,7 +33,7 @@ public struct SKU: Sendable, Codable {
     #if Non64BitSystemsCompatibility
       case __undocumented(UInt64)
     #else
-      case __undocumented(UInt)
+      case __undocumented(UInt64)
     #endif
   }
 

--- a/PaicordLib/Sources/DiscordModels/Types/Shared.swift
+++ b/PaicordLib/Sources/DiscordModels/Types/Shared.swift
@@ -281,72 +281,13 @@ public struct DiscordTimestamp: Codable, Hashable {
   public init(from decoder: any Decoder) throws {
     let container = try decoder.singleValueContainer()
     if let string = try? container.decode(String.self) {
-
-      let startIndex = string.startIndex
-      func index(_ offset: Int) -> String.Index {
-        string.index(startIndex, offsetBy: offset)
-      }
-
-      let components: DateComponents
-
-      if string.count == 32 {
-        guard let year = Int(string[startIndex...index(3)]),
-          let month = Int(string[index(5)...index(6)]),
-          let day = Int(string[index(8)...index(9)]),
-          let hour = Int(string[index(11)...index(12)]),
-          let minute = Int(string[index(14)...index(15)]),
-          let second = Int(string[index(17)...index(18)]),
-          let microSecond = Int(string[index(20)...index(25)])
-        else {
-          throw DecodingError.unexpectedFormat(container.codingPath, string)
-        }
-        components = DateComponents(
-          calendar: .utc,
-          year: year,
-          month: month,
-          day: day,
-          hour: hour,
-          minute: minute,
-          second: second,
-          nanosecond: microSecond * 1_000
-        )
-      } else if string.count == 25 {
-        guard let year = Int(string[startIndex...index(3)]),
-          let month = Int(string[index(5)...index(6)]),
-          let day = Int(string[index(8)...index(9)]),
-          let hour = Int(string[index(11)...index(12)]),
-          let minute = Int(string[index(14)...index(15)]),
-          let second = Int(string[index(17)...index(18)])
-        else {
-          throw DecodingError.unexpectedFormat(container.codingPath, string)
-        }
-        components = DateComponents(
-          calendar: .utc,
-          year: year,
-          month: month,
-          day: day,
-          hour: hour,
-          minute: minute,
-          second: second
-        )
-      } else {
+      guard let parsed = (try? Date.ISO8601FormatStyle(includingFractionalSeconds: true).parse(string))
+        ?? (try? Date.ISO8601FormatStyle().parse(string)) else {
         throw DecodingError.unexpectedFormat(container.codingPath, string)
       }
-      guard let date = Calendar.utc.date(from: components) else {
-        throw DecodingError.conversionFailure(
-          container.codingPath,
-          string,
-          components
-        )
-      }
-      self.date = date
-    } else if let int = try? container.decode(Int.self) {
-      self.date = Date(timeIntervalSince1970: TimeInterval(int))
+      date = parsed
     } else {
-      throw DecodingError.unexpectedFormat(
-        container.codingPath,
-        "Non String/Int value"
-      )
+      date = Date(timeIntervalSince1970: TimeInterval(try container.decode(Int64.self)))
     }
   }
 

--- a/PaicordLib/Sources/DiscordModels/Types/Shared.swift
+++ b/PaicordLib/Sources/DiscordModels/Types/Shared.swift
@@ -18,7 +18,7 @@ public enum StringIntDoubleBool: Sendable, Codable {
   }
 
   case string(String)
-  case int(Int)
+  case int(Int64)
   case double(Double)
   case bool(Bool)
 
@@ -44,7 +44,9 @@ public enum StringIntDoubleBool: Sendable, Codable {
   @inlinable
   public func requireInt() throws -> Int {
     switch self {
-    case .int(let int): return int
+    case .int(let int):
+      guard let value = Int(exactly: int) else { throw Error.valueIsNotOfType(Int.self, value: self) }
+      return value
     default: throw Error.valueIsNotOfType(Int.self, value: self)
     }
   }
@@ -71,7 +73,7 @@ public enum StringIntDoubleBool: Sendable, Codable {
     let container = try decoder.singleValueContainer()
     if let string = try? container.decode(String.self) {
       self = .string(string)
-    } else if let int = try? container.decode(Int.self) {
+    } else if let int = try? container.decode(Int64.self) {
       self = .int(int)
     } else if let bool = try? container.decode(Bool.self) {
       self = .bool(bool)
@@ -101,7 +103,7 @@ public enum StringIntDoubleBool: Sendable, Codable {
 /// To dynamically decode/encode String or Int.
 public enum StringOrInt: Sendable, Codable, Equatable, Hashable {
   case string(String)
-  case int(Int)
+  case int(Int64)
 
   public var asString: String {
     switch self {
@@ -115,7 +117,7 @@ public enum StringOrInt: Sendable, Codable, Equatable, Hashable {
     if let string = try? container.decode(String.self) {
       self = .string(string)
     } else {
-      let int = try container.decode(Int.self)
+      let int = try container.decode(Int64.self)
       self = .int(int)
     }
   }
@@ -134,12 +136,12 @@ public enum StringOrInt: Sendable, Codable, Equatable, Hashable {
 //MARK: - IntOrDouble
 
 public enum IntOrDouble: Sendable, Codable {
-  case int(Int)
+  case int(Int64)
   case double(Double)
 
   public init(from decoder: any Decoder) throws {
     let container = try decoder.singleValueContainer()
-    if let int = try? container.decode(Int.self) {
+    if let int = try? container.decode(Int64.self) {
       self = .int(int)
     } else {
       let double = try container.decode(Double.self)
@@ -283,7 +285,7 @@ public struct DiscordTimestamp: Codable, Hashable {
     if let string = try? container.decode(String.self) {
       guard let parsed = (try? Date.ISO8601FormatStyle(includingFractionalSeconds: true).parse(string))
         ?? (try? Date.ISO8601FormatStyle().parse(string)) else {
-        throw DecodingError.unexpectedFormat(container.codingPath, string)
+        throw Swift.DecodingError.dataCorruptedError(in: container, debugDescription: "Invalid ISO 8601 timestamp: \(string)")
       }
       date = parsed
     } else {

--- a/PaicordLib/Sources/DiscordModels/Types/Snowflake.swift
+++ b/PaicordLib/Sources/DiscordModels/Types/Snowflake.swift
@@ -40,7 +40,12 @@ extension SnowflakeProtocol {
   }
 
   public init(from decoder: any Decoder) throws {
-    try self.init(variable: .init(from: decoder))
+    let container = try decoder.singleValueContainer()
+    if let string = try? container.decode(String.self) {
+      self.init(string)
+    } else {
+      self.init(try container.decode(UInt64.self))
+    }
     #if DISCORDBM_ENABLE_LOGGING_DURING_DECODE
       if self.parse() == nil {
         DiscordGlobalConfiguration.makeDecodeLogger("SnowflakeProtocol")
@@ -184,11 +189,18 @@ public func == (lhs: any SnowflakeProtocol, rhs: any SnowflakeProtocol) -> Bool 
 /// The parsed info of a snowflake.
 public struct SnowflakeInfo: Sendable {
 
-  public enum Error: Swift.Error, CustomStringConvertible {
+  public enum Error: LocalizedError, CustomStringConvertible {
     /// Entered field '\(name)' is bigger than expected. It has a value of '\(value)', but max accepted is '\(max)'
-    case fieldTooBig(_ name: String, value: String, max: Int)
+    case fieldTooBig(_ name: String, value: String, max: UInt64)
     /// Entered field '\(name)' is smaller than expected. It has a value of '\(value)', but min accepted is '\(min)'
     case fieldTooSmall(_ name: String, value: String, min: UInt64)
+
+    public var errorDescription: String? {
+      switch self {
+      case .fieldTooBig(let name, let value, let max): return "Snowflake \(name) is \(value); the maximum is \(max)."
+      case .fieldTooSmall(let name, let value, let min): return "Snowflake \(name) is \(value); the minimum is \(min)."
+      }
+    }
 
     public var description: String {
       switch self {
@@ -232,21 +244,21 @@ public struct SnowflakeInfo: Sendable {
     processId: UInt8,
     sequenceNumber: UInt16
   ) throws {
-    guard timestamp <= (1 << 42) else {
-      throw Error.fieldTooBig("timestamp", value: "\(timestamp)", max: 1 << 42)
+    let maximum = Self.discordEpochConstant + (UInt64(1) << 42) - 1
+    guard timestamp >= Self.discordEpochConstant else {
+      throw Error.fieldTooSmall("timestamp", value: "\(timestamp)", min: Self.discordEpochConstant)
     }
-    guard workerId <= (1 << 5) else {
-      throw Error.fieldTooBig("workerId", value: "\(workerId)", max: 1 << 5)
+    guard timestamp <= maximum else {
+      throw Error.fieldTooBig("timestamp", value: "\(timestamp)", max: maximum)
     }
-    guard processId <= (1 << 5) else {
-      throw Error.fieldTooBig("processId", value: "\(processId)", max: 1 << 5)
+    guard workerId < 32 else {
+      throw Error.fieldTooBig("workerId", value: "\(workerId)", max: 31)
     }
-    guard sequenceNumber <= (1 << 12) else {
-      throw Error.fieldTooBig(
-        "sequenceNumber",
-        value: "\(sequenceNumber)",
-        max: 1 << 12
-      )
+    guard processId < 32 else {
+      throw Error.fieldTooBig("processId", value: "\(processId)", max: 31)
+    }
+    guard sequenceNumber < 4096 else {
+      throw Error.fieldTooBig("sequenceNumber", value: "\(sequenceNumber)", max: 4095)
     }
 
     self.timestamp = timestamp
@@ -268,49 +280,15 @@ public struct SnowflakeInfo: Sendable {
     processId: UInt8,
     sequenceNumber: UInt16
   ) throws {
-    guard
-      date.timeIntervalSince1970
-        >= Double(SnowflakeInfo.discordEpochConstant / 1_000)
-    else {
-      throw Error.fieldTooSmall(
-        "date",
-        value: "\(date.timeIntervalSince1970)",
-        min: SnowflakeInfo.discordEpochConstant / 1_000
-      )
+    let milliseconds = date.timeIntervalSince1970 * 1000
+    let maximum = Self.discordEpochConstant + (UInt64(1) << 42) - 1
+    guard milliseconds.isFinite, milliseconds < Double(maximum) + 1 else {
+      throw Error.fieldTooBig("date", value: "\(milliseconds)", max: maximum)
     }
-
-    let timeSince1970 = UInt64(date.timeIntervalSince1970)
-    guard timeSince1970 <= (1 << 42 / 1_000) else {
-      throw Error.fieldTooBig(
-        "date",
-        value: "\(timeSince1970)",
-        max: (1 << 42 / 1_000)
-      )
+    guard milliseconds >= Double(Self.discordEpochConstant) else {
+      throw Error.fieldTooSmall("date", value: "\(milliseconds)", min: Self.discordEpochConstant)
     }
-
-    self.timestamp = UInt64(date.timeIntervalSince1970 * 1_000)
-
-    guard timestamp < (1 << 42) else {
-      let max = (1 << 42 / 1_000) - 1
-      throw Error.fieldTooBig("date", value: "\(timestamp)", max: max)
-    }
-    guard workerId <= (1 << 5) else {
-      throw Error.fieldTooBig("workerId", value: "\(workerId)", max: 1 << 5)
-    }
-    guard processId <= (1 << 5) else {
-      throw Error.fieldTooBig("processId", value: "\(processId)", max: 1 << 5)
-    }
-    guard sequenceNumber <= (1 << 12) else {
-      throw Error.fieldTooBig(
-        "sequenceNumber",
-        value: "\(sequenceNumber)",
-        max: 1 << 12
-      )
-    }
-
-    self.workerId = workerId
-    self.processId = processId
-    self.sequenceNumber = sequenceNumber
+    try self.init(timestamp: UInt64(milliseconds), workerId: workerId, processId: processId, sequenceNumber: sequenceNumber)
   }
 
   /// Makes a fake snowflake.
@@ -535,7 +513,7 @@ public func murmurhash32(
   key: String,
   seed: Int = 0,
   signed: Bool = true
-) -> Int {
+) -> Int64 {
   // port of https://github.com/dolfies/discord.py-self/blob/530e72e03eebb2dff6f31ea456c7379ae88272bf/discord/utils.py#L1675-L1725
   // which is a modification of murmurhash3 function from https://github.com/wc-duck/pymmh3/blob/master/pymmh3.py
 
@@ -543,7 +521,7 @@ public func murmurhash32(
   let length = keyData.count
   let nblocks = length / 4
 
-  var h1 = UInt32(seed)
+  var h1 = UInt32(truncatingIfNeeded: seed)
   let c1: UInt32 = 0xCC9E_2D51
   let c2: UInt32 = 0x1B87_3593
 
@@ -589,9 +567,5 @@ public func murmurhash32(
   unsignedVal ^= unsignedVal >> 13
   unsignedVal = unsignedVal &* 0xC2B2_AE35
   unsignedVal ^= unsignedVal >> 16
-  if !signed || (unsignedVal & 0x8000_0000 == 0) {
-    return Int(unsignedVal)
-  } else {
-    return -Int((unsignedVal ^ 0xFFFF_FFFF) + 1)
-  }
+  return signed ? Int64(Int32(bitPattern: unsignedVal)) : Int64(unsignedVal)
 }

--- a/PaicordLib/Sources/DiscordModels/Types/User.swift
+++ b/PaicordLib/Sources/DiscordModels/Types/User.swift
@@ -68,7 +68,7 @@ public struct DiscordUser: Sendable, Codable, Equatable, Hashable {
   #if Non64BitSystemsCompatibility
     @UnstableEnum<UInt64>
   #else
-    @UnstableEnum<UInt>
+    @UnstableEnum<UInt64>
   #endif
   public enum Flag: Sendable {
     case staff  // 0
@@ -90,7 +90,7 @@ public struct DiscordUser: Sendable, Codable, Equatable, Hashable {
     #if Non64BitSystemsCompatibility
       case __undocumented(UInt64)
     #else
-      case __undocumented(UInt)
+      case __undocumented(UInt64)
     #endif
   }
 

--- a/PaicordLib/Sources/DiscordModels/Types/Voice.swift
+++ b/PaicordLib/Sources/DiscordModels/Types/Voice.swift
@@ -126,7 +126,7 @@ public struct VoiceStateUpdate: Sendable, Codable {
   #if Non64BitSystemsCompatibility
     @UnstableEnum<UInt64>
   #else
-    @UnstableEnum<UInt>
+    @UnstableEnum<UInt64>
   #endif
   public enum Flags: Sendable {
     case clipsEnabled  // 0
@@ -136,7 +136,7 @@ public struct VoiceStateUpdate: Sendable, Codable {
     #if Non64BitSystemsCompatibility
       case __undocumented(UInt64)
     #else
-      case __undocumented(UInt)
+      case __undocumented(UInt64)
     #endif
   }
 }


### PR DESCRIPTION
- Fix decoding on 32-bit watchOS
- Handle gateway packets without payload data
- Keep nested Discord error details
- Fix HTTP rate-limit timing
- Add regression tests
